### PR TITLE
Fix: Change sensor type parameter from string to SensorType enum

### DIFF
--- a/Abstracts/BaseSensor.cs
+++ b/Abstracts/BaseSensor.cs
@@ -1,8 +1,10 @@
+using sensors.Enums;
+
 namespace sensors.Abstracts
 {
-    public abstract class BaseSensor(string type)
+    public abstract class BaseSensor(SensorType type)
     {
-        public string Type { get; protected set; } = type ?? throw new ArgumentNullException(nameof(type));
+        public SensorType Type { get; protected set; } = type;
         public bool IsActive { get; protected set; } = false;
 
         public abstract void Activate();

--- a/Entities/IranianAgent.cs
+++ b/Entities/IranianAgent.cs
@@ -18,7 +18,7 @@ namespace sensors.Entities
             for (int i = 0; i < targetCount; i++)
             {
                 SensorType weaknessType = availableTypes[rnd.Next(availableTypes.Length)];
-                SecretWeaknesses.Add(new Sensor(weaknessType.ToString()));
+                SecretWeaknesses.Add(new Sensor(weaknessType));
             }
         }
 

--- a/Entities/Sensor.cs
+++ b/Entities/Sensor.cs
@@ -1,8 +1,9 @@
 using sensors.Abstracts;
+using sensors.Enums;
 
 namespace sensors.Entities
 {
-    public class Sensor(string type) : BaseSensor(type)
+    public class Sensor(SensorType type) : BaseSensor(type)
     {
         public override void Activate()
         {


### PR DESCRIPTION
- Updated BaseSensor and Sensor classes constructor to accept SensorType enum instead of string
- Fixed IranianAgent to pass SensorType directly instead of converting to string