### PR TITLE
Refactor sensor type handling and enhance logging

### DIFF
--- a/Entities/IranianAgent.cs
+++ b/Entities/IranianAgent.cs
@@ -22,10 +22,10 @@ namespace sensors.Entities
             }
         }
 
-        public override int Activate()
+        public override int ActivateInactiveSensors()
         {
-            Console.WriteLine($"Iranian agent activated. Rank: {Rank}");
-            return base.Activate();
+            Console.WriteLine($"Activating remaining sensors on {Rank} agent...");
+            return base.ActivateInactiveSensors();
         }
     }
 }

--- a/Enums/AttachmentResult.cs
+++ b/Enums/AttachmentResult.cs
@@ -1,0 +1,29 @@
+namespace sensors.Enums
+{
+    public enum AttachmentResult
+    {
+        Success,
+        AgentExposed,
+        AlreadyExposed,
+        InvalidSensor
+    }
+
+    public static class AttachmentResultExtensions
+    {
+        public static string GetMessage(this AttachmentResult result, int currentProgress = 0, int requiredProgress = 0)
+            => result switch
+            {
+                AttachmentResult.Success => $"Sensor attached successfully. Progress: {currentProgress}/{requiredProgress}",
+                AttachmentResult.AgentExposed => $"Well done! The agent has been exposed. ({currentProgress}/{requiredProgress})",
+                AttachmentResult.AlreadyExposed => "Agent is already exposed!",
+                AttachmentResult.InvalidSensor => "Invalid sensor provided.",
+                _ => throw new ArgumentOutOfRangeException(nameof(result))
+            };
+
+        public static bool IsSuccess(this AttachmentResult result)
+            => result == AttachmentResult.Success || result == AttachmentResult.AgentExposed;
+
+        public static bool IsFailure(this AttachmentResult result)
+            => !result.IsSuccess();
+    }
+}


### PR DESCRIPTION
## Changes

### Main improvements
- Renamed `Activate()` to `ActivateInactiveSensors()` - more descriptive name
- Fixed activation to only work on inactive sensors (was activating all sensors every time)
- Better user messages when activating sensors
- Cleaner progress display format

### What changed
**BaseAgent:**
- `ActivateInactiveSensors()` now skips already active sensors
- Shows grouped sensor types when activating (e.g. "Audio×2, Thermal")
- `AttachSensor()` returns enum instead of string for better type safety
- Improved `ToString()` format - cleaner and more readable

**IranianAgent:**
- Updated to use new method name
- Better activation message

### Why these changes
The old `Activate()` method would activate all sensors every time, even if they were already active. This was confusing and inefficient. Now it only activates sensors that aren't active yet.

Also separated the concerns better - attaching a sensor is different from activating it, so they should be separate operations.

### User experience
- More informative feedback when activating sensors
- Cleaner status display
- Progress shown consistently as "current/required"
- No more redundant sensor activations

**Breaking change:** Method renamed from `Activate()` to `ActivateInactiveSensors()`

### **Technical Details**

**Method Signature Changes**
```csharp
// Before
public virtual int Activate()
public virtual string AttachSensor(Sensor sensor)

// After  
public virtual int ActivateInactiveSensors()
public virtual AttachmentResult AttachSensor(Sensor sensor)